### PR TITLE
Save email verification token to person's pod

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -65,3 +65,6 @@ export const jwt = {
 export const emailDiscoveryType =
   process.env.EMAIL_DISCOVERY_TYPE ??
   'http://w3id.org/hospex/ns#PersonalHospexDocument'
+
+export const verificationTokenPredicate =
+  'https://example.com/emailVerificationToken'

--- a/src/controllers/integration.ts
+++ b/src/controllers/integration.ts
@@ -89,15 +89,19 @@ export const finishIntegration: Middleware = async ctx => {
   // save the token to person
   const savedTokensCount = await saveTokenToPerson(jwt, webId)
 
-  if (savedTokensCount === 0)
-    return ctx.throw(
-      400,
-      "We could't find any writeable location on your Pod to save the email verifiation token.",
-    )
-
-  ctx.response.body = jwt
-  ctx.set('content-type', 'text/plain')
-  ctx.response.status = 200
+  if (savedTokensCount === 0) {
+    ctx.response.status = 400
+    ctx.set('content-type', 'application/json')
+    ctx.response.body({
+      error:
+        "We could't find any writeable location on your Pod to save the email verifiation token. You can write it manually.",
+      token: jwt,
+    })
+  } else {
+    ctx.response.body = jwt
+    ctx.set('content-type', 'text/plain')
+    ctx.response.status = 200
+  }
 }
 
 /**

--- a/src/controllers/status.ts
+++ b/src/controllers/status.ts
@@ -1,14 +1,8 @@
-import { RdfQuery } from '@ldhop/core/dist/src'
-import { QueryAndStore } from '@ldhop/core/dist/src/QueryAndStore'
-import { fetchRdfDocument } from '@ldhop/core/dist/src/utils/helpers'
-import { getAuthenticatedFetch as getAuthenticatedFetch6x } from 'css-authn/dist/6.x'
-import { getAuthenticatedFetch as getAuthenticatedFetch7x } from 'css-authn/dist/7.x'
 import { readFile } from 'fs-extra'
 import { verify } from 'jsonwebtoken'
 import type { DefaultContext, DefaultState, Middleware } from 'koa'
-import { NamedNode, Quad } from 'n3'
-import { dct, rdfs, solid, space } from 'rdf-namespaces'
 import * as config from '../config'
+import { findEmailVerificationTokens } from '../utils'
 
 export const getVerifiedEmails = async (webId: string) => {
   const tokens = await findEmailVerificationTokens(webId)
@@ -45,115 +39,4 @@ export const getStatus: Middleware<
 
   ctx.response.body = { emailVerified: verifiedEmails.length > 0 }
   ctx.response.status = 200
-}
-
-/**
- * To find verified email of a person
- *
- * - Go to person's webId
- * - Find public type index `(webId) - solid:publicTypeIndex -> (publicTypeIndex)``
- * - Find instances of specific class defined in config (EMAIL_DISCOVERY_TYPE defaults to hospex:PersonalHospexDocument)
- * - Find settings in the relevant instance (webId) - space:preferencesFile -> (settings)
- * - In the settings, find (webId) - example:emailVerificationToken -> (JWT)
- */
-const findEmailQuery: RdfQuery = [
-  // Go to person's webId and fetch extended profile documents, too
-  {
-    type: 'match',
-    subject: '?person',
-    predicate: rdfs.seeAlso,
-    pick: 'object',
-    target: '?extendedDocument',
-  },
-  { type: 'add resources', variable: '?extendedDocument' },
-  // Find public type index
-  {
-    type: 'match',
-    subject: '?person',
-    predicate: solid.publicTypeIndex,
-    pick: 'object',
-    target: '?publicTypeIndex',
-  },
-  // Find instances of specific class defined in config (EMAIL_DISCOVERY_TYPE)
-  {
-    type: 'match',
-    subject: '?publicTypeIndex',
-    predicate: dct.references,
-    pick: 'object',
-    target: '?typeRegistration',
-  },
-  {
-    type: 'match',
-    subject: '?typeRegistration',
-    predicate: solid.forClass,
-    object: config.emailDiscoveryType,
-    pick: 'subject',
-    target: '?typeRegistrationForClass',
-  },
-  {
-    type: 'match',
-    subject: '?typeRegistrationForClass',
-    predicate: solid.instance,
-    pick: 'object',
-    target: `?classDocument`,
-  },
-  { type: 'add resources', variable: '?classDocument' },
-  // Find settings
-  {
-    type: 'match',
-    subject: '?person',
-    predicate: space.preferencesFile,
-    pick: 'object',
-    target: '?settings',
-  },
-  { type: 'add resources', variable: '?settings' },
-]
-
-const findEmailVerificationTokens = async (webId: string) => {
-  // initialize knowledge graph and follow your nose through it
-  // according to the query
-  const qas = new QueryAndStore(findEmailQuery, { person: new Set([webId]) })
-  await run(qas)
-
-  // Find email verification tokens
-  const objects = qas.store.getObjects(
-    new NamedNode(webId),
-    new NamedNode('https://example.com/emailVerificationToken'),
-    null,
-  )
-
-  return objects.map(o => o.value)
-}
-
-const fetchRdf = async (uri: string) => {
-  const getAuthenticatedFetch =
-    config.mailerCredentials.cssVersion === 6
-      ? getAuthenticatedFetch6x
-      : getAuthenticatedFetch7x
-  const authBotFetch = await getAuthenticatedFetch(config.mailerCredentials)
-
-  const { data: quads } = await fetchRdfDocument(uri, authBotFetch)
-
-  return quads
-}
-
-/**
- * Follow your nose through the linked data graph by query
- */
-const run = async (qas: QueryAndStore) => {
-  let missingResources = qas.getMissingResources()
-
-  while (missingResources.length > 0) {
-    let quads: Quad[] = []
-    const res = missingResources[0]
-    try {
-      quads = await fetchRdf(missingResources[0])
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error(e)
-    } finally {
-      qas.addResource(res, quads)
-      missingResources = qas.getMissingResources()
-    }
-  }
 }

--- a/src/test/helpers/index.ts
+++ b/src/test/helpers/index.ts
@@ -5,6 +5,8 @@ import { createSandbox } from 'sinon'
 import { v4 as uuidv4 } from 'uuid'
 import * as config from '../../config'
 import * as mailerService from '../../services/mailerService'
+import { setupEmailSettings } from './setupPod'
+import { Person } from './types'
 
 export const createRandomAccount = ({
   solidServer,
@@ -54,15 +56,26 @@ const finishIntegration = async (verificationLink: string) => {
 
 export const verifyEmail = async ({
   email,
+  person,
   authenticatedFetch,
 }: {
   email: string
+  person: Person
   authenticatedFetch: typeof fetch
 }) => {
+  await setupEmailSettings({
+    person,
+    email: '',
+    emailVerificationToken: '',
+    authenticatedFetch,
+    skipSettings: true,
+  })
+
   const { verificationLink } = await initIntegration({
     email,
     authenticatedFetch,
   })
+
   const { token } = await finishIntegration(verificationLink)
 
   return token

--- a/src/test/helpers/setupPod.ts
+++ b/src/test/helpers/setupPod.ts
@@ -106,7 +106,7 @@ export const setupEmailSettings = async ({
     : `
   <${person.webId}>
     <${foaf.mbox}> "${email}";
-    <https://example.com/emailVerificationToken> "${emailVerificationToken}".`
+    <${config.verificationTokenPredicate}> "${emailVerificationToken}".`
   const settingsPath = person.podUrl + 'hospex/email'
 
   await createFile({
@@ -158,6 +158,12 @@ export const setupEmailSettings = async ({
     inserts: profileDocumentPatch,
     authenticatedFetch,
   })
+
+  return {
+    settings: settingsPath,
+    hospexDocument: hospexDocumentPath,
+    publicTypeIndex: publicTypeIndexPath,
+  }
 }
 
 const addAcl = async ({

--- a/src/test/notification.spec.ts
+++ b/src/test/notification.spec.ts
@@ -7,7 +7,6 @@ import { baseUrl } from '../config'
 import type { GoodBody } from '../controllers/notification'
 import * as mailerService from '../services/mailerService'
 import { verifyEmail } from './helpers'
-import { setupEmailSettings } from './helpers/setupPod'
 import {
   authenticatedFetch,
   authenticatedFetch3,
@@ -19,6 +18,9 @@ import {
 
 const email = 'email@example.com'
 
+/**
+ * Generate body for POST /notification
+ */
 const getBody = ({
   from,
   to,
@@ -41,14 +43,9 @@ describe('send notification via /notification', () => {
 
   beforeEach(async () => {
     // setup email for receiver
-    const token = await verifyEmail({
+    await verifyEmail({
       email,
-      authenticatedFetch: authenticatedFetch3,
-    })
-    await setupEmailSettings({
       person: person3,
-      email,
-      emailVerificationToken: token,
       authenticatedFetch: authenticatedFetch3,
     })
   })

--- a/src/test/status.spec.ts
+++ b/src/test/status.spec.ts
@@ -3,7 +3,6 @@ import fetch from 'cross-fetch'
 import { describe } from 'mocha'
 import { baseUrl } from '../config'
 import { verifyEmail } from './helpers'
-import { setupEmailSettings } from './helpers/setupPod'
 import {
   authenticatedFetch,
   authenticatedFetch3,
@@ -17,13 +16,7 @@ const email = 'email@example.com'
 
 describe('get info about integrations of a person with GET /status/:webId', () => {
   beforeEach(async () => {
-    const token = await verifyEmail({ email, authenticatedFetch })
-    await setupEmailSettings({
-      person,
-      email,
-      emailVerificationToken: token,
-      authenticatedFetch,
-    })
+    await verifyEmail({ email, authenticatedFetch, person })
   })
 
   it('[not authenticated] should fail with 401', async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,204 @@
+import { RdfQuery } from '@ldhop/core/dist/src'
+import { QueryAndStore } from '@ldhop/core/dist/src/QueryAndStore'
+import { fetchRdfDocument } from '@ldhop/core/dist/src/utils/helpers'
+import { getAuthenticatedFetch as getAuthenticatedFetch6x } from 'css-authn/dist/6.x'
+import { getAuthenticatedFetch as getAuthenticatedFetch7x } from 'css-authn/dist/7.x'
+import { NamedNode, Quad } from 'n3'
+import { dct, rdfs, solid, space } from 'rdf-namespaces'
+import * as config from './config'
+
+/**
+ * To find verified email of a person
+ *
+ * - Go to person's webId
+ * - Find public type index `(webId) - solid:publicTypeIndex -> (publicTypeIndex)``
+ * - Find instances of specific class defined in config (EMAIL_DISCOVERY_TYPE defaults to hospex:PersonalHospexDocument)
+ * - Find settings in the relevant instance (webId) - space:preferencesFile -> (settings)
+ * - In the settings, find (webId) - example:emailVerificationToken -> (JWT)
+ */
+const findEmailQuery: RdfQuery = [
+  // Go to person's webId and fetch extended profile documents, too
+  {
+    type: 'match',
+    subject: '?person',
+    predicate: rdfs.seeAlso,
+    pick: 'object',
+    target: '?extendedDocument',
+  },
+  { type: 'add resources', variable: '?extendedDocument' },
+  // Find public type index
+  {
+    type: 'match',
+    subject: '?person',
+    predicate: solid.publicTypeIndex,
+    pick: 'object',
+    target: '?publicTypeIndex',
+  },
+  // Find instances of specific class defined in config (EMAIL_DISCOVERY_TYPE)
+  {
+    type: 'match',
+    subject: '?publicTypeIndex',
+    predicate: dct.references,
+    pick: 'object',
+    target: '?typeRegistration',
+  },
+  {
+    type: 'match',
+    subject: '?typeRegistration',
+    predicate: solid.forClass,
+    object: config.emailDiscoveryType,
+    pick: 'subject',
+    target: '?typeRegistrationForClass',
+  },
+  {
+    type: 'match',
+    subject: '?typeRegistrationForClass',
+    predicate: solid.instance,
+    pick: 'object',
+    target: `?classDocument`,
+  },
+  { type: 'add resources', variable: '?classDocument' },
+  // Find settings
+  {
+    type: 'match',
+    subject: '?person',
+    predicate: space.preferencesFile,
+    pick: 'object',
+    target: '?settings',
+  },
+  { type: 'add resources', variable: '?settings' },
+]
+
+/**
+ * Search through person's storage and find email verification token in settings
+ */
+export const findEmailVerificationTokens = async (webId: string) => {
+  // initialize knowledge graph and follow your nose through it
+  // according to the query
+  const qas = new QueryAndStore(findEmailQuery, { person: new Set([webId]) })
+  await run(qas)
+
+  // Find email verification tokens
+  const objects = qas.store.getObjects(
+    new NamedNode(webId),
+    new NamedNode(config.verificationTokenPredicate),
+    null,
+  )
+
+  return objects.map(o => o.value)
+}
+
+/**
+ * Given a webId of person, find settings that the bot identity can write to
+ */
+export const findWritableSettings = async (webId: string) => {
+  // initialize knowledge graph and follow your nose through it
+  // according to the query
+  const qas = new QueryAndStore(findEmailQuery, { person: new Set([webId]) })
+  await run(qas)
+
+  // get uris of settings
+  const settings = qas.getVariable('settings')
+
+  // find out which settings the bot can edit
+  const authBotFetch = await getBotFetch()
+  const results = await Promise.allSettled(
+    settings.map(s => getAllowedAccess(s, authBotFetch)),
+  )
+
+  const writableSettings = settings.filter((setting, index) => {
+    const result = results[index]
+    return (
+      result.status === 'fulfilled' &&
+      (result.value.user.includes('write') ||
+        result.value.user.includes('append'))
+    )
+  })
+
+  return writableSettings
+}
+
+type Permission = 'read' | 'write' | 'append' | 'control'
+type PermissionDict = {
+  user: Permission[]
+  public: Permission[]
+}
+
+/**
+ * Parse WAC-Allow header
+ * https://solid.github.io/web-access-control-spec/#wac-allow
+ * user="append read write",public="read"
+ */
+const parseWACAllowHeader = (header: string): PermissionDict => {
+  const result: PermissionDict = { user: [], public: [] }
+
+  const entries = header.split(',')
+
+  for (const entry of entries) {
+    const [key, value] = entry.split('=') as ['user' | 'public', string]
+    result[key] = value.trim().replace(/"/g, '').split(' ') as Permission[]
+  }
+
+  return result
+}
+
+/**
+ * Given url, find what kind of accesses current user has
+ * and what kind of accesses public has
+ *
+ * This is done via WAC-Allow header
+ * https://solid.github.io/web-access-control-spec/#wac-allow
+ */
+const getAllowedAccess = async (
+  url: string,
+  authenticatedFetch: typeof fetch,
+) => {
+  const response = await authenticatedFetch(url, { method: 'head' })
+  const header = response.headers.get('wac-allow')
+  if (header === null)
+    throw new Error('WAC-Allow header not found for resource ' + url)
+  const permissions = parseWACAllowHeader(header)
+
+  return permissions
+}
+
+/**
+ * Get authenticated fetch for the notification bot identity defined in config
+ */
+export const getBotFetch = async () => {
+  const getAuthenticatedFetch =
+    config.mailerCredentials.cssVersion === 6
+      ? getAuthenticatedFetch6x
+      : getAuthenticatedFetch7x
+  return await getAuthenticatedFetch(config.mailerCredentials)
+}
+
+/**
+ * Fetch RDF document with notification bot identity, and return quads
+ */
+export const fetchRdf = async (uri: string) => {
+  const authBotFetch = await getBotFetch()
+  const { data: quads } = await fetchRdfDocument(uri, authBotFetch)
+  return quads
+}
+
+/**
+ * Follow your nose through the linked data graph by query
+ */
+const run = async (qas: QueryAndStore) => {
+  let missingResources = qas.getMissingResources()
+
+  while (missingResources.length > 0) {
+    let quads: Quad[] = []
+    const res = missingResources[0]
+    try {
+      quads = await fetchRdf(missingResources[0])
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e)
+    } finally {
+      qas.addResource(res, quads)
+      missingResources = qas.getMissingResources()
+    }
+  }
+}


### PR DESCRIPTION
To do this, person has to prepare their pod by creating a settings file that notification service identity has write or append access to. The service also needs read access to every file that participates in the discovery, in particular personal hospex profile.

The settings are discovered as follows:

1. we start with person's webId
1. we fetch (extended) profile and find public type index
1. in public type index, we find resources that are relevant in this particular context (e.g. personal hospex document in case of sleepy.bike)
1. in these resources, we find settings by searching triple `<webId> space:preferencesFile <settings> .`
1.
    - to write verification token, we pick the settings which _notification service identity_ has access to, using [WAC-Allow header](https://solid.github.io/web-access-control-spec/#wac-allow)
    - to read verification token, we look for triple `<webId> <https://example.com/emailVerificationToken> "token" .`
        the predicate for token discovery is editable in config, but should be kept consistent